### PR TITLE
Add setup script and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: ./setup.sh
+      - run: npm run lint --if-present

--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ A secure habit-tracking, journaling, and messaging app with gamification element
 - **Backend**: Node.js, Express, MongoDB
 - **Frontend**: React.js, Redux, CSS
 - **Security**: End-to-End Encryption, JWT Auth
+
+## Setup
+After cloning the repository, install dependencies by running:
+
+```bash
+./setup.sh
+```
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+if [ ! -d node_modules ]; then
+    npm ci
+fi


### PR DESCRIPTION
## Summary
- provide a setup script for installing Node dependencies
- document how to use the script
- run the script in a simple CI workflow

## Testing
- `./setup.sh` *(fails: cannot download packages)*
- `npm run lint` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684d88b2bef08331bf8fd1ae41f3c41b